### PR TITLE
[NCA-1182] Fix batch predictions breaking when the returned prediction had null values 

### DIFF
--- a/dr_streamlit/predictor.py
+++ b/dr_streamlit/predictor.py
@@ -78,7 +78,7 @@ def submit_batch_prediction(deployment: Deployment, df: pd.DataFrame, max_explan
                     'featureValue': getattr(row, f'EXPLANATION_{i}_ACTUAL_VALUE'),
                     'strength': getattr(row, f'EXPLANATION_{i}_STRENGTH'),
                     'qualitativeStrength': getattr(row, f'EXPLANATION_{i}_QUALITATIVE_STRENGTH'),
-                } for i in range(1, max_explanations + 1) if (hasattr(row, f'EXPLANATION_{i}_FEATURE_NAME') and type(getattr(row, f'EXPLANATION_{i}_FEATURE_NAME')) == str)
+                } for i in range(1, max_explanations + 1) if (hasattr(row, f'EXPLANATION_{i}_FEATURE_NAME') and not pd.isna(getattr(row, f'EXPLANATION_{i}_FEATURE_NAME')))
             ]
         scored_predictions.append(record)
     return {'data': scored_predictions}

--- a/dr_streamlit/predictor.py
+++ b/dr_streamlit/predictor.py
@@ -78,10 +78,9 @@ def submit_batch_prediction(deployment: Deployment, df: pd.DataFrame, max_explan
                     'featureValue': getattr(row, f'EXPLANATION_{i}_ACTUAL_VALUE'),
                     'strength': getattr(row, f'EXPLANATION_{i}_STRENGTH'),
                     'qualitativeStrength': getattr(row, f'EXPLANATION_{i}_QUALITATIVE_STRENGTH'),
-                } for i in range(1, max_explanations + 1) if hasattr(row, f'EXPLANATION_{i}_FEATURE_NAME')
+                } for i in range(1, max_explanations + 1) if (hasattr(row, f'EXPLANATION_{i}_FEATURE_NAME') and type(getattr(row, f'EXPLANATION_{i}_FEATURE_NAME')) == str)
             ]
         scored_predictions.append(record)
-
     return {'data': scored_predictions}
 
 


### PR DESCRIPTION
When submitting a prediction, the real-time API returns a json and the batch API returns a csv. If the model only has a couple (eg 4) features but you requested many (eg 8) prediction explanations then you might end up with a situation where you don't get all 8 prediction explanations. In this case the single prediction API will send back a JSON with the explanations list with less than 8 entries -- BUT the batch prediction CSV will have empty columns. 

In order to parse these CSVs to have parity with the real-time API we need to filter out these null values. 