### PR TITLE
Assign binary classification preds for pos class

### DIFF
--- a/dr_streamlit/predictor.py
+++ b/dr_streamlit/predictor.py
@@ -81,7 +81,7 @@ def submit_batch_prediction(deployment: Deployment, df: pd.DataFrame, max_explan
         record = dict()
         if project.target_type == TARGET_TYPE.BINARY:
             record['prediction_values'] = [
-                {'value': getattr(row, f'{target}_{index}_PREDICTION'), 'label': float(index)} for index in [0, 1]
+                {'value': getattr(row, f'{target}_{project.positive_class}_PREDICTION'), 'label': project.positive_class}
             ],
         elif project.target_type == TARGET_TYPE.REGRESSION:
             record['prediction'] = getattr(row, f'{target}_PREDICTION')

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -80,7 +80,8 @@ def predictor_app():
             if type(prediction_values[0]) in [tuple, list]:
                 # Some are like this
                 prediction_values = prediction_values[0]
-            prediction = next(pred_value['value'] for pred_value in prediction_values if pred_value['label'] == 0.0)
+            # Assign prediction for the positive class label
+            prediction = next(pred_value['value'] for pred_value in prediction_values if pred_value['label'] == project.positive_class)
         elif project.target_type == TARGET_TYPE.REGRESSION:
             prediction = pred['data'][0]['prediction']
         elif project.target_type == TARGET_TYPE.MULTICLASS:


### PR DESCRIPTION
Changed the assignment of prediction values for binary classification projects to look for the project's positive class rather than 0/1. 

Batch predictions only assign the positive class prediction, but this is usually what users will want anyway. Negative class predictions can be calculated with something like `1.0 - positive_class_prediction`.