### PR TITLE
Fix the way we specify the port in our Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,9 +14,17 @@ RUN pip3 install -r requirements.txt
 
 COPY . .
 
-ENV STREAMLIT_SERVER_PORT 80
-EXPOSE 80
+ARG port=80
+ENV STREAMLIT_SERVER_PORT ${port}
+EXPOSE ${port}
 
 HEALTHCHECK CMD curl --fail http://localhost:${STREAMLIT_SERVER_PORT}/_stcore/health
+
+ARG deploymentId
+ARG projectId
+ARG apiToken
+ENV deploymentid=${deploymentId} \
+    projectid=${projectId} \
+    token=${apiToken}
 
 ENTRYPOINT ["streamlit", "run", "streamlit_app.py", "--server.address=0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,12 +9,14 @@ RUN apt-get update && apt-get install -y \
     git \
     && rm -rf /var/lib/apt/lists/*
 
-COPY . .
-
+COPY requirements.txt requirements.txt
 RUN pip3 install -r requirements.txt
 
+COPY . .
+
+ENV STREAMLIT_SERVER_PORT 80
 EXPOSE 80
 
-HEALTHCHECK CMD curl --fail http://localhost:80/_stcore/health
+HEALTHCHECK CMD curl --fail http://localhost:${STREAMLIT_SERVER_PORT}/_stcore/health
 
-ENTRYPOINT ["streamlit", "run", "streamlit_app.py", "--server.port=80", "--server.address=0.0.0.0"]
+ENTRYPOINT ["streamlit", "run", "streamlit_app.py", "--server.address=0.0.0.0"]


### PR DESCRIPTION
To make our docker image more friendly with running in the custom-apps infra, we must override the http port setting using an env var so this way the custom app infra can override it when it is running there (command line flags cannot be overridden).

Also make some minor tweaks to the image to improve layer caching and also add more build-time arguments so it is also possible to bake certain values into the image (which is currently required in the custom-apps infrastructure).